### PR TITLE
Providing closing </span> tag for IE8

### DIFF
--- a/countdown/jquery.countdown.js
+++ b/countdown/jquery.countdown.js
@@ -78,7 +78,7 @@
 
 		// Creating the markup inside the container
 		$.each(['Days','Hours','Minutes','Seconds'],function(i){
-			$('<span class="count'+this+'">').html(
+			$('<span class="count'+this+'"></span>').html(
 				'<span class="position">\
 					<span class="digit static">0</span>\
 				</span>\


### PR DESCRIPTION
Without both the opening and closing tags, IE8 will not add the necessary markup. This does not affect any other browsers experience.
